### PR TITLE
Video Processing

### DIFF
--- a/processmedia/encode.sh
+++ b/processmedia/encode.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#
+# Requirements:
+# - avconv (ffmpeg's new command line video converter)
+# - libavcodec with patented format support (ubuntu package libavcodec-extra-53)
+# - sox
+#
+# Usage:
+#  ./encode.sh Some_Song/Original_Download.flv
+#
+# Outputs:
+# - Some_Song/thumb.jpg     (320x240 JPG)
+# - Some_Song/video.mp4     (full size H264/AAC)
+# - Some_Song/preview.mp4   (320x240 H264/AAC with fade out)
+#
+# TODO: hard code subtitles
+#
+
+
+PREVIEW_LENGTH=15
+FADE_LENGTH=5
+FPS=29
+DIR="`dirname \"$1\"`"
+
+
+# pick a thumbnail 4 seconds in
+avconv -y -itsoffset -4 -i "$1" -vcodec mjpeg -vframes 1 -an -f rawvideo -s 320x240 $DIR/thumb.jpg
+
+
+# encode full-size video into a chrome-friendly format
+avconv -y -i "$1" -vcodec libx264 -acodec libvo_aacenc $DIR/video.mp4
+
+
+# extract and fade out audio preview
+avconv -y -i "$1" -t 00:00:$PREVIEW_LENGTH -vn -f aiff pipe: | \
+	sox -t aiff - -t aiff - fade t 0 00:00:$PREVIEW_LENGTH $FADE_LENGTH | \
+	avconv -i pipe: $DIR/preview.m4a
+
+# extract and fade out video preview
+avconv -y -i "$1" -t 00:00:$PREVIEW_LENGTH -an -s 320x240 \
+	-vf fade=out:$(($FPS*$PREVIEW_LENGTH-$FPS*$FADE_LENGTH)):$(($FPS*$FADE_LENGTH)) \
+	-vcodec libx264 $DIR/preview.m4v
+
+# merge previews
+avconv -y -i $DIR/preview.m4a -i $DIR/preview.m4v -acodec copy -vcodec copy $DIR/preview.mp4
+
+# tidy up
+rm -f $DIR/preview.m4a $DIR/preview.m4v

--- a/processmedia/encode_all.sh
+++ b/processmedia/encode_all.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for orig in files/*/[A-Z]* ; do
+	./encode.sh "$orig"
+done

--- a/processmedia/files
+++ b/processmedia/files
@@ -1,0 +1,1 @@
+../mediaserver/www/files/


### PR DESCRIPTION
Script to encode any video into chrome-compatible video / preview / thumbnail, currently doesn't handle subtitles. Adding extra output formats for different browsers should be pretty simple.

`encode_all.sh` assumes files are laid out as files/Song_Name/Original_Video.avi (`files` folder is hardcoded, and is currently a symlink to the media server file store; song_name can be anything; Original_Video.avi can be anything that starts with a capital letter - the capital makes it easy to detect the original video vs video.mp4 / preview.mp4 / thumb.jpg)
