### PR TITLE
with a wide screen, have the lyrics and preview side-by-side

### DIFF
--- a/website/karakara/static/css/main.css
+++ b/website/karakara/static/css/main.css
@@ -54,6 +54,18 @@ HTML.video    .hide_if_html5_video    {display: none;}
     width : 100%;
 }
 
+/* for wide screens, have the video and lyrics side-by-side instead of making the video HUGE */
+@media all and (min-width: 800px) {
+    .video_placeholder {
+        width: 50%;
+        float: right;
+        margin-left: 30px;
+    }
+    .add-to-queue-box {
+        width: 45%;
+    }
+}
+
 .track_title {
     text-align: center;
     font-size: 130%;

--- a/website/karakara/templates/html/track.mako
+++ b/website/karakara/templates/html/track.mako
@@ -102,7 +102,7 @@
 ## Actions ---------------------------------------------------------------------
 
 <!-- Queue -->
-<div data-role="collapsible">
+<div class='add-to-queue-box' data-role="collapsible">
     <h3>Queue Track</h3>
     % if not (identity and identity.get('admin',False)) and request.registry.settings.get('karakara.system.user.readonly'):
         <p>Queuing tracks has been disabled</p>


### PR DESCRIPTION
Browsing tracks on a laptop or desktop, the preview video gets scaled up to full-screen size, which is much bigger than needed (and having a thumbnail-sized video scaled up that much gives lots of scaling artefacts)
