### PR TITLE
Add (Karaoke Ver) to 'vocaltrack=off' tracks in the printed track list

### DIFF
--- a/website/karakara/views/queue_settings.py
+++ b/website/karakara/views/queue_settings.py
@@ -89,7 +89,7 @@ DEFAULT_SETTINGS = {
     'karakara.search.list.alphabetical.threshold': 90,
     'karakara.search.list.alphabetical.tags': '[from, artist]',
 
-    'karakara.print_tracks.fields': '[category, from, use, title, artist, vocaltrack, length]',
+    'karakara.print_tracks.fields': '[category, from, use, title, artist, length]',
     'karakara.print_tracks.short_id_length': 4,
 
     'karakara.event.end': '',

--- a/website/karakara/views/queue_track_list.py
+++ b/website/karakara/views/queue_track_list.py
@@ -66,6 +66,8 @@ def track_list_all(request):
     short_id_length = request.queue.settings.get('karakara.print_tracks.short_id_length', 6)
     for track in track_list:
         track['id_short'] = track['id'][:short_id_length]
+        if track['tags'].get('vocaltrack') == ["off"]:
+            track['title'] += " (Karaoke Ver)"
 
     # Sort track list
     #  this needs to be handled at the python layer because the tag logic is fairly compicated


### PR DESCRIPTION
~90% of tracks have vocals - instead of having a whole column for "vocaltrack on/off", we can just specially mark the few who don't, and then get rid of that column which saves a bunch of space (and is easier to read IMO).

Previously:

```
Track         | Vocaltrack
A             | On
B             | On
C             | On
D             | Off
E             | On
F             | On
G             | On
```

With this patch:

```
Track
A
B
C
D (Karaoke Ver)
E
F
G
```