### PR TITLE
Print the tracklist as landscape with two columns

### DIFF
--- a/website/karakara/static/css/print_list.css
+++ b/website/karakara/static/css/print_list.css
@@ -1,6 +1,13 @@
+@page {
+    size: landscape;
+}
 html {
     font-family: sans-serif;
     padding: 0.5em;
+}
+body {
+    column-count: 2;
+    column-rule: 1px solid black;
 }
 table {
     font-size: 8px;


### PR DESCRIPTION
Right now the track list is ~2/3 white space - printing it as two columns side by side means we can fit the same information in half the space.

Seems that this only works properly on chrome though :( Firefox does columns for text, but it refuses to break the single table across columns...

Before:

<img width="380" alt="screen shot 2018-08-04 at 03 34 48" src="https://user-images.githubusercontent.com/40659/43671732-5d191c90-9797-11e8-9358-36717be01d0f.png">

After:

<img width="380" alt="screen shot 2018-08-04 at 03 34 00" src="https://user-images.githubusercontent.com/40659/43671728-4359c5e8-9797-11e8-9720-6c7a15d28af7.png">
