### PR TITLE
allow multiple fields per column on the track list

### DIFF
--- a/website/karakara/templates/html/track_list.mako
+++ b/website/karakara/templates/html/track_list.mako
@@ -13,19 +13,33 @@
         <table>
             <thead>
                 <tr>
-                    % for field in fields:
-                    <th>${field}</th>
-                    % endfor
+                % for column in fields:
+                    <th>
+                        % for n, field in enumerate(column.split("-")):
+                            % if n > 0:
+                                -
+                            % endif
+                            ${field}
+                        % endfor
+                    </th>
+                % endfor
                 </tr>
             </thead>
             <tbody>
-        % for track in data.get('list',[]):
-<tr>\
-                % for field in fields:
-<td class="col_${field}">${track.get(field,'') or h.tag_hireachy(track['tags'], field) }</td>\
+            % for track in data.get('list',[]):
+                <tr>\
+                % for column in fields:
+                    <td class="col_${column}">
+                    % for n, field in enumerate(column.split("-")):
+                        % if n > 0:
+                            -
+                        % endif
+                        ${track.get(field,'') or h.tag_hireachy(track['tags'], field)}
+                    % endfor
+                    </td>\
                 % endfor
-</tr>
-        % endfor
+                </tr>
+            % endfor
             </tbody>
         </table>
     </body>

--- a/website/karakara/views/queue_settings.py
+++ b/website/karakara/views/queue_settings.py
@@ -89,7 +89,7 @@ DEFAULT_SETTINGS = {
     'karakara.search.list.alphabetical.threshold': 90,
     'karakara.search.list.alphabetical.tags': '[from, artist]',
 
-    'karakara.print_tracks.fields': '[category, from, use, title, artist, vocaltrack, length]',
+    'karakara.print_tracks.fields': '[category-from, title-artist, vocaltrack, length]',
     'karakara.print_tracks.short_id_length': 4,
 
     'karakara.event.end': '',

--- a/website/karakara/views/queue_track_list.py
+++ b/website/karakara/views/queue_track_list.py
@@ -71,7 +71,11 @@ def track_list_all(request):
     #  this needs to be handled at the python layer because the tag logic is fairly compicated
     fields = request.queue.settings.get('karakara.print_tracks.fields', [])
     def key_track(track):
-        return " ".join([tag_hireachy(track['tags'], field) for field in fields])
+        parts = []
+        for column in fields:
+            for field in column.split("-"):
+                parts.append(tag_hireachy(track['tags'], field))
+        return " ".join(parts)
     track_list = sorted(track_list, key=key_track)
 
     return action_ok(data={'list': track_list})


### PR DESCRIPTION
Allow the config `[a, b-c, d-e, f]` so that we have 4 columns with `a`, `b + c`, `d + e`, `f`. I find that this makes the layout much more efficient.

Before:

```
Category              From              Title              Artist
Anime                 A                 Some long title    A
Anime, Cartoon        B                 B                  B
Anime                 The Cake Show     C                  C
Anime                 D                 D                  Several, Artists
```

After:

```
Category - From           Title - Artist
Anime - A                 Some long title - A
Anime, Cartoon - B        B - B
Anime - The Cake Show     C - C
Anime - D                 D - Several, Artists
```