### PR TITLE
Use a python Enum for queue item status

### DIFF
--- a/player2/src/player.js
+++ b/player2/src/player.js
@@ -2,7 +2,7 @@ import { app } from "hyperapp";
 import ReconnectingWebSocket from "reconnecting-websocket";
 import queryString from 'query-string';
 
-import { state, actions } from "./state";
+import { state, actions, QueueItemStatus } from "./state";
 import { view } from "./view";
 import {get_protocol, get_hostname, get_ws_port, get_queue_id, is_podium} from "./util";
 
@@ -50,7 +50,7 @@ function create_websocket() {
         const commands = {
             // Skip action requires the player to send the ended signal to poke the correct api endpoint.
             // This feel ineligant fix. Advice please.
-            "skip": () => is_podium() ? null : player.set_track_status('skipped'),
+            "skip": () => is_podium() ? null : player.set_track_status(QueueItemStatus.SKIPPED),
             "play": player.play,
             "stop": player.stop,
             "pause": player.pause,

--- a/player2/src/state.js
+++ b/player2/src/state.js
@@ -2,6 +2,18 @@ import {get_lyrics, api} from "./util";
 
 
 // ====================================================================
+// State constants
+// ====================================================================
+
+const QueueItemStatus = {
+    PENDING: "pending",
+    PLAYED: "played",
+    SKIPPED: "skipped",
+    REMOVED: "removed",
+};
+
+
+// ====================================================================
 // State and state management functions
 // ====================================================================
 
@@ -147,4 +159,4 @@ const actions = {
     },
 };
 
-export {state, actions};
+export {state, actions, QueueItemStatus};

--- a/player2/src/view.js
+++ b/player2/src/view.js
@@ -11,6 +11,7 @@ import {
     get_file_root,
     get_theme_var
 } from "./util.js";
+import { QueueItemStatus } from './state';
 
 const show_tracks = 5;
 
@@ -130,7 +131,7 @@ const VideoScreen = ({state, actions}) => (
         <video src={get_attachment(state, state.queue[0].track, 'video')}
                autoPlay={true}
                ontimeupdate={(e) => actions.set_progress(e.target.currentTime)}
-               onended={() => actions.set_track_status("played")}
+               onended={() => actions.set_track_status(QueueItemStatus.PLAYED)}
         />
         <div id="seekbar" style={{
             left: ((state.progress / state.queue[0].track.duration) * 100) + "%"


### PR DESCRIPTION
Named constants means it's much harder to make typos or mix up things like "played" and "ended"

(This will become even more important after the server-side status stuff where we have more statuses to take care of; I'm submitting this for review by itself to avoid putting too many changes in the server-side-state patch)