### PR TITLE
Use integers for Queue Item IDs

### DIFF
--- a/api_queue/api_queue/server.py
+++ b/api_queue/api_queue/server.py
@@ -140,7 +140,7 @@ class QueueItemJson:
     session_id: str
     performer_name: str
     start_time: float
-    id: float
+    id: int
 #    on = bool
 #    doors = int
 #    color = str
@@ -227,12 +227,12 @@ async def add_queue_item(request, queue_id):
 
 @queue_blueprint.delete("/<queue_id:str>/")
 @openapi.definition(
-    parameter=openapi.definitions.Parameter('queue_item_id', float, required=True, allowEmptyValue=False, location='query'),
+    parameter=openapi.definitions.Parameter('queue_item_id', int, required=True, allowEmptyValue=False, location='query'),
     response=openapi.definitions.Response({"application/json": QueueItemJson}),
 )
 async def delete_queue_item(request, queue_id):
     try:
-        queue_item_id = float(request.args.get('queue_item_id'))
+        queue_item_id = int(request.args.get('queue_item_id'))
     except (ValueError, TypeError):
         raise sanic.exceptions.InvalidUsage(message="queue_item_id arg required")
     async with push_queue_to_mqtt(request, queue_id):
@@ -247,8 +247,8 @@ async def delete_queue_item(request, queue_id):
 
 
 class QueueItemMove:
-    queue_item_id_1: float
-    queue_item_id_2: float
+    queue_item_id_1: int
+    queue_item_id_2: int
 @queue_blueprint.put("/<queue_id:str>/")
 @openapi.definition(
     body={"application/json": QueueItemMove},
@@ -256,8 +256,8 @@ class QueueItemMove:
 )
 async def move_queue_item(request, queue_id):
     try:
-        queue_item_id_1 = float(request.args.get('queue_item_id_1'))
-        queue_item_id_2 = float(request.args.get('queue_item_id_2'))
+        queue_item_id_1 = int(request.args.get('queue_item_id_1'))
+        queue_item_id_2 = int(request.args.get('queue_item_id_2'))
     except (ValueError, TypeError):
         raise sanic.exceptions.InvalidUsage(message="queue_item_id_1 and queue_item_id_2 args required", context=request.args)
     if request.ctx.session_id != 'admin':

--- a/api_queue/tests/test_app.py
+++ b/api_queue/tests/test_app.py
@@ -103,10 +103,10 @@ async def test_queue_move(queue_model, mock_mqtt):
     mock_mqtt.publish.reset_mock()
     response = await queue_model.put()
     assert response.status == 400
-    response = await queue_model.put(queue_item_id_1=0.0, queue_item_id_2=0.0)
+    response = await queue_model.put(queue_item_id_1=0, queue_item_id_2=0)
     assert response.status == 403
     queue_model.session_id = 'admin'
-    response = await queue_model.put(queue_item_id_1=0.0, queue_item_id_2=0.0)
+    response = await queue_model.put(queue_item_id_1=0, queue_item_id_2=0)
     assert response.status == 400
     mock_mqtt.publish.assert_not_awaited()
 


### PR DESCRIPTION
Floating point numbers can have rounding issues when we're transferring data between Python and JS, or between 64-bit servers and 32-bit phones, etc - the server says "the next track in the list is 0.666" and the client says "Ah I see, the next track is 0.67"

This PR changes things to use 30-bit integers, which should be lossless across all platforms