### PR TITLE
don't push to dockerhub

### DIFF
--- a/.github/workflows/api_queue.yml
+++ b/.github/workflows/api_queue.yml
@@ -1,15 +1,17 @@
-name: api_queue
+name: Queue API
 
 on:
   push:
     paths:
     - 'api_queue/**'
+    - '.github/workflows/api_queue.yml'
 
 jobs:
   publish:
-    name: Docker build
+    name: Docker Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout
+      uses: actions/checkout@master
     - name: Test build
       run: make --directory=api_queue _build

--- a/.github/workflows/browser2.yml
+++ b/.github/workflows/browser2.yml
@@ -4,17 +4,15 @@ on:
   push:
     paths:
     - 'browser2/**'
+    - '.github/workflows/browser2.yml'
 
 jobs:
   publish:
-    name: Docker Push
+    name: Docker Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: karakara/browser2
-        workdir: browser2
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Build
+      run: docker build .
+      working-directory: browser2

--- a/.github/workflows/player2.yml
+++ b/.github/workflows/player2.yml
@@ -4,17 +4,15 @@ on:
   push:
     paths:
     - 'player2/**'
+    - '.github/workflows/player2.yml'
 
 jobs:
   publish:
-    name: Docker Push
+    name: Docker Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: karakara/player2
-        workdir: player2
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Build
+      run: docker build .
+      working-directory: browser2

--- a/.github/workflows/processmedia2.yml
+++ b/.github/workflows/processmedia2.yml
@@ -4,17 +4,15 @@ on:
   push:
     paths:
     - 'processmedia2/**'
+    - '.github/workflows/processmedia2.yml'
 
 jobs:
   publish:
-    name: Docker Push
+    name: Docker Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: karakara/processmedia2
-        workdir: processmedia2
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Build
+      run: docker build .
+      working-directory: processmedia2

--- a/README.md
+++ b/README.md
@@ -70,13 +70,7 @@ $ cp .env.example .env
 ```
 Then edit settings in .env
 
-Pre-built software, if you just want to run the site:
-```console
-$ docker-compose pull
-$ docker-compose up
-```
-
-Compile your own software, if you want to make customisations or build new features:
+Then build and run the software:
 ```console
 $ docker-compose build
 $ docker-compose up


### PR DESCRIPTION
Just do `docker build` to make sure that the images build (each of them includes their own tests as part of the build process) - no need to push to dockerhub since that just leaves out-of-date images there, it's more consistent to build from source