### PR TITLE
`POST login.json` to set admin cookie

### DIFF
--- a/api_queue/api_queue/server.py
+++ b/api_queue/api_queue/server.py
@@ -101,7 +101,7 @@ async def attach_session_id_request(request):
     request.ctx.is_admin = request.ctx.session_id == "admin"
 @app.middleware("response")
 async def attach_session_id(request, response):
-    if not request.cookies.get("session_id"):
+    if request.cookies.get("session_id") != request.ctx.session_id:
         response.cookies["session_id"] = request.ctx.session_id
 
 
@@ -150,6 +150,24 @@ class QueueItemJson:
 #    passengers = openapi.Array(Driver, required=["name", "birthday"])
 
 
+
+
+class AdminLogin:
+    password: str
+@queue_blueprint.post("/<queue_id:str>/login.json")
+@openapi.definition(
+    body={"application/json": AdminLogin},
+    response=[
+        openapi.definitions.Response({"application/json": {"is_admin": bool}}, status=200),
+    ],
+)
+async def login(request, queue_id):
+    if queue_id == request.json["password"]:
+        request.ctx.session_id = "admin"
+        return sanic.response.json({"is_admin": True})
+    else:
+        request.ctx.session_id = str(random.random())
+        return sanic.response.json({"is_admin": False})
 
 
 #@app.get("/queue/<queue_id:str>/tracks.json")


### PR DESCRIPTION
Mixing the code for "manage session ID" and "manage is-admin boolean" on the client is hard, and the code for logging in with a password is there already...

Having an API function which accepts this password and sets the admin cookie for us is actually easier than setting the cookie for ourselves, _and_ it's easy to replace with some real authentication if we want to do that in the future.