### PR TITLE
[api_queue] reload track.json when it changes

### DIFF
--- a/api_queue/api_queue/server.py
+++ b/api_queue/api_queue/server.py
@@ -9,9 +9,6 @@ import sanic
 from sanic_ext import openapi
 from sanic.log import logger as log
 
-from ._utils import harden
-
-
 
 app = sanic.Sanic("karakara_queue")
 app.config.update({
@@ -34,16 +31,10 @@ app.ext.openapi.describe(
 
 # Startup ----------------------------------------------------------------------
 
+from .track_manager import TrackManager
 @app.listener('before_server_start')
 async def tracks_load(_app: sanic.Sanic, _loop):
-    path_tracks = Path(str(_app.config.get('PATH_TRACKS')))
-    log.info(f"[tracks] loading - {path_tracks=}")
-    if path_tracks.is_file():
-        with path_tracks.open() as filehandle:
-            _app.ctx.tracks = harden(json.load(filehandle))
-    else:
-        log.error('No tracks.json file present or provided. api_queue WILL NOT FUNCTION IN PRODUCTION. processmedia2 should output this file when encoding is complete')
-        _app.ctx.tracks = {}
+    _app.ctx.track_manager = TrackManager(Path(str(_app.config.get('PATH_TRACKS'))))
 
 
 from .queue_model import QueueItem
@@ -247,11 +238,12 @@ class QueueItemAdd:
     ],
 )
 async def add_queue_item(request, queue_id):
+    tracks = request.app.ctx.track_manager.tracks
     # Validation
     if not request.json or frozenset(request.json.keys()) != frozenset(('track_id', 'performer_name')):
         raise sanic.exceptions.InvalidUsage(message="missing fields", context=request.json)
     track_id = request.json['track_id']
-    if track_id not in request.app.ctx.tracks:
+    if track_id not in tracks:
         raise sanic.exceptions.InvalidUsage(message="track_id invalid", context=track_id)
     performer_name = request.json['performer_name']
     # Queue update
@@ -259,7 +251,7 @@ async def add_queue_item(request, queue_id):
         async with request.app.ctx.queue_manager.async_queue_modify_context(queue_id) as queue:
             queue_item = QueueItem(
                 track_id=track_id,
-                track_duration=request.app.ctx.tracks[track_id]["duration"],
+                track_duration=tracks[track_id]["duration"],
                 session_id=request.ctx.session_id,
                 performer_name=performer_name,
             )

--- a/api_queue/api_queue/track_manager.py
+++ b/api_queue/api_queue/track_manager.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import logging
+import json
+
+from ._utils import harden
+
+log = logging.getLogger(__name__)
+
+
+class TrackManager:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.mtime = 0
+        self._tracks = {}
+        if not path.is_file():
+            log.error('No tracks.json file present or provided. api_queue WILL NOT FUNCTION IN PRODUCTION. processmedia2 should output this file when encoding is complete')
+
+    @property
+    def tracks(self):
+        mtime = self.path.stat().st_mtime
+        if mtime != self.mtime:
+            self.mtime = mtime
+            with self.path.open() as filehandle:
+                self._tracks = harden(json.load(filehandle))
+        return self._tracks


### PR DESCRIPTION
I can't figure out a good approach for this, but this seems like a not-awful one... sending as a pull request rather than committing straight to master, because I'm not sure and would value a second opinion.

- If we have processmedia notify the API server whenever it has finished processing, how does that work when encoding happens on a different machine, offline, and the results are sync'ed via syncthing a few hours later? What if we have many people sharing the same dataset but running their own servers? My gut tells me that processmedia should _only_ care about the `source` folder and the `processed` folder, and have no other inputs or outputs

- My other idea was using inotify to monitor tracks.json for changes, but that appears to have issues when the server runs inside docker, and the file is modified outside of it.