### PR TITLE
[api_queue] reload track.json when it changes

### DIFF
--- a/api_queue/api_queue/track_manager.py
+++ b/api_queue/api_queue/track_manager.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import logging
+import json
+import typing as t
+
+from ._utils import harden
+
+log = logging.getLogger(__name__)
+
+
+class TrackManager:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.mtime = 0
+        self._tracks: t.Dict[str, t.Any] = {}
+        if not path.is_file():
+            log.error('No tracks.json file present or provided. api_queue WILL NOT FUNCTION IN PRODUCTION. processmedia2 should output this file when encoding is complete')
+
+    @property
+    def tracks(self):
+        mtime = self.path.stat().st_mtime
+        if mtime != self.mtime:
+            self.mtime = mtime
+            with self.path.open() as filehandle:
+                self._tracks = harden(json.load(filehandle))
+        return self._tracks


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/calaldees/KaraKara/pull/151).
* __->__ #151

[api_queue] reload track.json when it changes

I can't figure out a good approach for this, but this seems like a not-awful one... sending as a pull request rather than committing straight to master, because I'm not sure and would value a second opinion.

- This approach: have a `TrackManager` class with a `.tracks` property which always has up-to-date tracks in it. The current implementation does this by checking the file's last-modified timestamp and reloading it if it's changed.

- Alternative idea 1: Have processmedia notify the API server whenever it has finished processing -- how does that work when encoding happens on a different machine, offline, and the results are sync'ed via syncthing a few hours later? What if we have many people sharing the same dataset but running their own servers? My gut tells me that processmedia should _only_ care about the `source` folder and the `processed` folder, and have no other inputs or outputs

- Alternative idea 2: Use inotify to monitor tracks.json for changes -- that appears to have issus when the server runs inside docker, and the file is modified outside of it.

