### PR TITLE
[api] if a room doesn't exist, and the user isn't an admin, have /room/login.json API return 404

### DIFF
--- a/api_queue/api_queue/server.py
+++ b/api_queue/api_queue/server.py
@@ -192,6 +192,10 @@ class LoginRequest:
     ],
 )
 async def login(request, room_name):
+    if not request.app.ctx.settings_manager.room_exists(room_name):
+        if not request.json.get("create"):
+            raise sanic.exceptions.NotFound(message=f"Room '{room_name}' not found")
+        request.app.ctx.settings_manager.set_json(room_name, {})
     user = LoginManager.login(room_name, None, request.json["password"], request.ctx.session_id)
     request.ctx.session_id = user.session_id
     return sanic.response.json(user.__dict__)

--- a/api_queue/api_queue/settings_manager.py
+++ b/api_queue/api_queue/settings_manager.py
@@ -55,6 +55,9 @@ class SettingsManager():
         assert path.is_dir()
         self.path = path
 
+    def room_exists(self, name: str) -> bool:
+        return self.path.joinpath(f'{name}_settings.json').is_file()
+
     def get_json(self, name: str) -> dict:
         path = self.path.joinpath(f'{name}_settings.json')
         if not path.is_file():


### PR DESCRIPTION
[api] if a room doesn't exist, and the user isn't an admin, have /room/login.json API return 404

If an admin uses the settings screen to enter a room name + password at the same time, then the room will be created - this just stops end-users from entering the wrong name
