### PR TITLE
[nginx] performer name isn't stored in a cookie any more

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -37,8 +37,7 @@ http {
         '"request_time":"$request_time",'
         '"request_id":"$request_id",'
         '"http_referrer":"$http_referer",'
-        '"http_user_agent":"$http_user_agent",'
-        '"cookie_performer_name":"$cookie_performer_name"'
+        '"http_user_agent":"$http_user_agent"'
     '}';
 
     server {


### PR DESCRIPTION
[nginx] performer name isn't stored in a cookie any more
