### PR TITLE
[pm3] Ignore non-UTF8 data in ffprobe output

### DIFF
--- a/processmedia3/lib/kktypes.py
+++ b/processmedia3/lib/kktypes.py
@@ -116,7 +116,7 @@ class MediaMeta(t.NamedTuple):
         if completed_process.returncode:
             log.debug(f'Unable to ffprobe {uri}')
             return cls()
-        ffprobe_output = completed_process.stderr.decode('utf8')
+        ffprobe_output = completed_process.stderr.decode('utf8', errors="ignore")
 
         fps = 0.0
         if match := re.search(r'(\d{1,3}(\.\d+)?) fps', ffprobe_output):


### PR DESCRIPTION

Some files have Shift-JIS(?) metadata in the file headers (ie Japanese artist names) - but we don't care about that, we're only looking at the metadata to find the height / width / duration
