### PR TITLE
[pl3] splash scale manual override

### DIFF
--- a/player3/src/providers/client.tsx
+++ b/player3/src/providers/client.tsx
@@ -21,7 +21,9 @@ export interface ClientContextType {
     wakeLock: string;
     underscan: string;
     setUnderscan: (n: string) => void;
-};
+    splashScale: number;
+    setSplashScale: (n: number) => void;
+}
 
 export const ClientContext = React.createContext<ClientContextType>({
     root: "",
@@ -42,6 +44,8 @@ export const ClientContext = React.createContext<ClientContextType>({
     wakeLock: "",
     underscan: "0em",
     setUnderscan: (_) => null,
+    splashScale: 1.0,
+    setSplashScale: (_) => null,
 });
 
 export function ClientProvider(props: any) {
@@ -67,6 +71,10 @@ export function ClientProvider(props: any) {
     const [audioAllowed, setAudioAllowed] = useState<boolean>(false);
     const [fullscreen, setFullscreen] = useState<boolean>(false);
     const [wakeLock, setWakeLock] = useState<string>("Not supported");
+    const [splashScale, setSplashScale] = useLocalStorage<number>(
+        "splash_scale",
+        1.0,
+    );
 
     const { isSupported, request } = useWakeLock({
         onRequest: () => setWakeLock("Requested"),
@@ -106,6 +114,8 @@ export function ClientProvider(props: any) {
                 wakeLock,
                 underscan,
                 setUnderscan,
+                splashScale,
+                setSplashScale,
             }}
         >
             {props.children}

--- a/player3/src/providers/room.tsx
+++ b/player3/src/providers/room.tsx
@@ -15,7 +15,7 @@ export interface RoomContextType {
     setQueue: (q: QueueItem[]) => void;
     settings: Record<string, any>;
     connected: boolean;
-};
+}
 
 export const RoomContext = React.createContext<RoomContextType>({
     isAdmin: false,

--- a/player3/src/providers/server.tsx
+++ b/player3/src/providers/server.tsx
@@ -10,7 +10,7 @@ export interface ServerContextType {
     downloadDone: number;
     now: number;
     offset: number;
-};
+}
 
 export const ServerContext = React.createContext<ServerContextType>({
     tracks: {},

--- a/player3/src/screens/_common.tsx
+++ b/player3/src/screens/_common.tsx
@@ -8,7 +8,7 @@ import type { Track, Attachment } from "../types";
 interface VideoProps {
     track: Track;
     [Key: string]: any;
-};
+}
 export function Video({ track, ...kwargs }: VideoProps) {
     const { root } = useContext(ClientContext);
     return (

--- a/player3/src/screens/config.tsx
+++ b/player3/src/screens/config.tsx
@@ -20,6 +20,8 @@ export function ConfigMenu() {
         wakeLock,
         underscan,
         setUnderscan,
+        splashScale,
+        setSplashScale,
     } = useContext(ClientContext);
     const { now, offset } = useContext(ServerContext);
     const [rootEdit, setRootEdit] = useState(root);
@@ -161,6 +163,23 @@ export function ConfigMenu() {
                                         onChange={(e) =>
                                             setUnderscan(e.target.value)
                                         }
+                                    />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Splash Scale</td>
+                                <td>
+                                    <input
+                                        type="number"
+                                        value={splashScale}
+                                        onChange={(e) =>
+                                            setSplashScale(
+                                                parseFloat(e.target.value),
+                                            )
+                                        }
+                                        step={0.1}
+                                        min={0.1}
+                                        max={2.0}
                                     />
                                 </td>
                             </tr>

--- a/player3/src/screens/preview.tsx
+++ b/player3/src/screens/preview.tsx
@@ -50,7 +50,9 @@ export function PreviewScreen({
                         />
                         <p className="title">{track.tags.title[0]}</p>
                         <p className="from">
-                            {track.tags.from?.[0] ?? track.tags.artist?.join(", ") ?? ""}
+                            {track.tags.from?.[0] ??
+                                track.tags.artist?.join(", ") ??
+                                ""}
                         </p>
                         <p className="performer">
                             <span className="n">{idx + 1}</span>{" "}

--- a/player3/src/screens/title.tsx
+++ b/player3/src/screens/title.tsx
@@ -146,6 +146,7 @@ function MyScene() {
     const { settings } = useContext(RoomContext);
     const { tracks } = useContext(ServerContext);
     const widescreen = useMediaQuery("(min-aspect-ratio: 16/10)");
+    const { splashScale }  = useContext(ClientContext);
 
     const globe = useRef<Group>(null);
     const text1 = useRef<Group>(null);
@@ -167,8 +168,8 @@ function MyScene() {
         state.gl.getContext().getShaderInfoLog = () => "";
     });
     useFrame((state, _delta) => {
-        const cam = state.camera as THREE.PerspectiveCamera;
-        cam.fov = widescreen ? 50 : 65;
+        const cam = (state.camera as THREE.PerspectiveCamera);
+        cam.fov = (widescreen ? 50 : 65) * (1/splashScale);
         cam.updateProjectionMatrix();
 
         const t = state.clock.getElapsedTime();
@@ -182,11 +183,7 @@ function MyScene() {
     return (
         <>
             <ambientLight intensity={0.3} />
-            <directionalLight
-                color="#29EDF2"
-                position={[-4, 2, 5]}
-                intensity={3}
-            />
+            <directionalLight color="#29EDF2" position={[-4, 2, 5]} intensity={3} />
             <group position={[3, -0.25, 0]} rotation={[0, 0, -0.15]}>
                 <group ref={globe}>
                     <mesh>

--- a/player3/src/static/style.scss
+++ b/player3/src/static/style.scss
@@ -59,6 +59,7 @@ MAIN {
             margin: 0;
         }
         INPUT[type="text"],
+        INPUT[type="number"],
         BUTTON {
             width: 100%;
         }


### PR DESCRIPTION

There was an issue where the splash screen 3D elements were too large and covering up the 2D elements. It turned out that the Three API changed and we needed to call a new `updateProjectionMatrix()` to get the auto-scaling to work properly, so manual scaling wasn't needed, but keeping this code around for reference just in case.
