### PR TITLE
[pm3] split classes to avoid circular dependencies

### DIFF
--- a/processmedia3/lib/encoders.py
+++ b/processmedia3/lib/encoders.py
@@ -11,7 +11,8 @@ import math
 
 import tqdm
 
-from .kktypes import Source, SourceType, TargetType, MediaType, MediaMeta
+from .source import Source, SourceType
+from .kktypes import TargetType, MediaType, MediaMeta
 from .subtitle_processor import create_vtt, parse_subtitles
 
 log = logging.getLogger()

--- a/processmedia3/lib/kktypes.py
+++ b/processmedia3/lib/kktypes.py
@@ -1,33 +1,13 @@
-import base64
-import hashlib
 import logging
 import re
-import shutil
 import subprocess
-import tempfile
-import copy
-from collections import defaultdict
 import enum
-from pathlib import Path
 import typing as t
-from collections.abc import Sequence, Mapping, MutableMapping, MutableSequence, Set
 from fractions import Fraction
 from datetime import timedelta
 
-from .subtitle_processor import parse_subtitles, Subtitle
-from .tag_processor import parse_tags
-from .file_abstraction import AbstractFile
-
 log = logging.getLogger()
 T = t.TypeVar("T")
-
-
-class SourceType(enum.Enum):
-    VIDEO = frozenset({".mp4", ".mkv", ".avi", ".mpg", ".webm"})
-    AUDIO = frozenset({".mp3", ".flac", ".ogg", ".aac"})
-    IMAGE = frozenset({".jpg", ".png", ".webp", ".avif"})
-    TAGS = frozenset({".txt"})
-    SUBTITLES = frozenset({".srt", ".ssa"})
 
 
 class TargetType(enum.Enum):
@@ -69,6 +49,7 @@ class MediaMeta(t.NamedTuple):
     def from_uri(cls, uri, _subprocess_run: t.Callable[...,subprocess.CompletedProcess]=subprocess.run) -> t.Self:
         r"""
         >>> from textwrap import dedent
+        >>> from pathlib import Path
 
         >>> from unittest.mock import Mock
         >>> def from_uri(fake_ffprobe_stderr):
@@ -140,205 +121,3 @@ class MediaMeta(t.NamedTuple):
             aspect_ratio = Fraction(int(match.group(1)), int(match.group(2)))
 
         return cls(fps, width, height, duration, aspect_ratio)
-
-
-class Source:
-    """
-    A file in the "source" directory, with some convenience methods
-    to parse data out of the file (hash, duration, etc) efficiently
-    """
-
-    def __init__(self, file: AbstractFile, cache: MutableMapping[str, t.Any]):
-        self.file = file
-        self.cache = cache
-        self.type: SourceType | None = next((type for type in SourceType if self.file.suffix in type.value), None)
-        if not self.type:
-            raise Exception(f"Can't tell what type of source {self.file.relative} is")
-
-    @staticmethod
-    def _cache(func: t.Callable[["Source"], T]) -> t.Callable[["Source"], T]:
-        """
-        if `self.cache[self.file.name self.file.mtime func.name]` is set,
-        return that, else call func() and add the value to the cache
-        """
-
-        def inner(self: "Source") -> T:
-            # Normalise mtime to accuracy of 1min. This enables remote and local timestamps to match
-            # Technically there is a possibility of an update that is missed, but it's pretty edge case for our usecase
-            mtime = int(self.file.mtime.replace(second=0, microsecond=0).timestamp())
-            key = f"{self.file.relative}-{mtime}-{func.__name__}"
-            cached = self.cache.get(key)
-            if not cached:
-                cached = func(self)
-                self.cache[key] = cached
-            return cached
-
-        return inner
-
-    @property
-    @_cache
-    def hash(self) -> str:
-        log.info(f"Hashing {self.file.relative}")
-        return self.file.hash
-
-    @property
-    @_cache
-    def meta(self) -> MediaMeta:
-        log.info(f"Parsing meta from {self.file.relative}")
-        return MediaMeta.from_uri(self.file.absolute)
-
-    @property
-    @_cache
-    def subtitles(self) -> Sequence[Subtitle]:
-        log.info(f"Parsing subtitles from {self.file.relative}")
-        return parse_subtitles(self.file.text)
-
-    @property
-    def lyrics(self) -> Sequence[str]:
-        return [l.text for l in self.subtitles]
-
-    @property
-    @_cache
-    def tags(self) -> Mapping[str, Sequence[str]]:
-        log.info(f"Parsing tags from {self.file.relative}")
-        return parse_tags(self.file.text)
-
-
-class Target:
-    """
-    A file in the "processed" directory, with a method to figure out
-    the target name (based on the hash of the source files + encoder
-    settings), and a method to create that file if it doesn't exist.
-    """
-
-    def __init__(
-        self, processed_dir: Path, type: TargetType, sources: Set[Source]
-    ) -> None:
-        from .encoders import find_appropriate_encoder  # circular import :(
-
-        self.processed_dir = processed_dir
-        self.type = type
-        self.encoder, self.sources = find_appropriate_encoder(type, sources)
-
-        parts = [self.encoder.salt] + [s.hash for s in self.sources]
-        hasher = hashlib.sha256()
-        hasher.update("".join(sorted(parts)).encode("ascii"))
-        hash = re.sub("[+/=]", "_", base64.b64encode(hasher.digest()).decode("ascii"))
-        self.friendly = hash[0].lower() + "/" + hash[:11] + "." + self.encoder.ext
-        self.path = (
-            processed_dir / hash[0].lower() / (hash[:11] + "." + self.encoder.ext)
-        )
-        log.debug(
-            f"Filename for {self.encoder.__class__.__name__} = {self.friendly} based on {parts}"
-        )
-
-    def encode(self) -> None:
-        log.info(
-            f"{self.encoder.__class__.__name__}("
-            f"{self.friendly!r}, "
-            f"{[s.file.relative for s in self.sources]})"
-        )
-        with tempfile.TemporaryDirectory() as tempdir:
-            temppath = Path(tempdir) / ("out." + self.encoder.ext)
-            try:
-                self.encoder.encode(temppath, self.sources)
-                if not temppath.exists():
-                    raise Exception("Encoder didn't return any error, but failed to create an output file")
-                if temppath.stat().st_size == 0:
-                    raise Exception("Encoder didn't return any error, but created an empty file")
-                self.path.parent.mkdir(exist_ok=True)
-                log.debug(f"Moving {temppath} to {self.path}")
-                shutil.move(temppath.as_posix(), self.path.as_posix())
-            except Exception as e:
-                log.error(f"Error while encoding {self.friendly!r}: {e}")
-
-    def __str__(self):
-        source_list = [s.file.relative for s in self.sources]
-        return f"{self.type.name}: {self.friendly!r} = {self.encoder.__class__.__name__}({source_list!r})"
-
-class TrackAttachment(t.TypedDict):
-    mime: str
-    path: str
-class TrackDict(t.TypedDict):
-    id: str
-    duration: float
-    attachments: Mapping[MediaType, Sequence[TrackAttachment]]
-    lyrics: Sequence[str]
-    tags: Mapping[str, Sequence[str]]
-
-
-class Track:
-    """
-    An entry in tracks.json, keeping track of which source files are
-    used to build the track, which target files should be generated,
-    and a method to dump all the metadata into a json dict.
-    """
-
-    def __init__(
-        self,
-        processed_dir: Path,
-        id: str,
-        sources: Set[Source],
-        target_types: Sequence[TargetType],
-    ) -> None:
-        self.id = id
-        self.sources = sources
-        self.targets = [Target(processed_dir, type, sources) for type in target_types]
-
-    def _sources_by_type(self, types: Set[SourceType]) -> Sequence[Source]:
-        return [s for s in self.sources if s.type in types]
-
-    @property
-    def has_tags(self) -> bool:
-        return bool(self._sources_by_type({SourceType.TAGS}))
-
-    def to_json(self) -> TrackDict:
-        media_files = self._sources_by_type({SourceType.VIDEO, SourceType.AUDIO})
-        duration = media_files[0].meta.duration.total_seconds()
-
-        attachments: MutableMapping[MediaType, MutableSequence[TrackAttachment]] = defaultdict(list)
-        for target in self.targets:
-            attachments[target.encoder.category].append(
-                TrackAttachment({
-                    "mime": target.encoder.mime,
-                    "path": str(target.path.relative_to(target.processed_dir)),
-                })
-            )
-        assert attachments.get(MediaType.VIDEO), f"{self.id} is missing attachments.video"
-        #assert attachments.get(MediaType.PREVIEW), f"{self.id} is missing attachments.preview"
-        assert attachments.get(MediaType.IMAGE), f"{self.id} is missing attachments.image"
-
-        sub_files = self._sources_by_type({SourceType.SUBTITLES})
-        lyrics = sub_files[0].lyrics if sub_files else []
-
-        tag_files = self._sources_by_type({SourceType.TAGS})
-        tags: MutableMapping[str, MutableSequence[str]] = copy.deepcopy(tag_files[0].tags)  # type: ignore[arg-type]
-        assert tags.get("title") is not None, f"{self.id} is missing tags.title"
-        assert tags.get("category") is not None, f"{self.id} is missing tags.category"
-
-        if self._sources_by_type({SourceType.SUBTITLES}):
-            tags["subs"] = ["soft"]
-        else:
-            tags["subs"] = ["hard"]
-        tags["source_type"] = []
-        if self._sources_by_type({SourceType.IMAGE}):
-            tags["source_type"].append("image")
-        if self._sources_by_type({SourceType.VIDEO}):
-            tags["source_type"].append("video")
-        pxsrc = self._sources_by_type({SourceType.VIDEO, SourceType.IMAGE})[0]
-        tags["aspect_ratio"] = [pxsrc.meta.aspect_ratio_str]
-
-        ausrc = self._sources_by_type({SourceType.VIDEO, SourceType.AUDIO})[0]
-        d = int(ausrc.meta.duration.total_seconds())
-        tags["duration"] = [f"{d//60}m{d%60:02}s"]
-
-        if tags.get("date"):
-            tags["year"] = [d.split("-")[0] for d in tags["date"]]
-
-        return TrackDict(
-            id=self.id,
-            duration=round(duration, 1),  # for more consistent unit tests
-            attachments=attachments,
-            lyrics=lyrics,
-            tags=tags,
-        )

--- a/processmedia3/lib/source.py
+++ b/processmedia3/lib/source.py
@@ -1,0 +1,82 @@
+import enum
+import typing as t
+import logging
+from collections.abc import Sequence, Mapping, MutableMapping
+
+from .subtitle_processor import parse_subtitles, Subtitle
+from .tag_processor import parse_tags
+from .file_abstraction import AbstractFile
+from .kktypes import MediaMeta
+
+log = logging.getLogger()
+T = t.TypeVar("T")
+
+
+class SourceType(enum.Enum):
+    VIDEO = frozenset({".mp4", ".mkv", ".avi", ".mpg", ".webm"})
+    AUDIO = frozenset({".mp3", ".flac", ".ogg", ".aac"})
+    IMAGE = frozenset({".jpg", ".png", ".webp", ".avif"})
+    TAGS = frozenset({".txt"})
+    SUBTITLES = frozenset({".srt", ".ssa"})
+
+
+class Source:
+    """
+    A file in the "source" directory, with some convenience methods
+    to parse data out of the file (hash, duration, etc) efficiently
+    """
+
+    def __init__(self, file: AbstractFile, cache: MutableMapping[str, t.Any]):
+        self.file = file
+        self.cache = cache
+        self.type: SourceType | None = next((type for type in SourceType if self.file.suffix in type.value), None)
+        if not self.type:
+            raise Exception(f"Can't tell what type of source {self.file.relative} is")
+
+    @staticmethod
+    def _cache(func: t.Callable[["Source"], T]) -> t.Callable[["Source"], T]:
+        """
+        if `self.cache[self.file.name self.file.mtime func.name]` is set,
+        return that, else call func() and add the value to the cache
+        """
+
+        def inner(self: "Source") -> T:
+            # Normalise mtime to accuracy of 1min. This enables remote and local timestamps to match
+            # Technically there is a possibility of an update that is missed, but it's pretty edge case for our usecase
+            mtime = int(self.file.mtime.replace(second=0, microsecond=0).timestamp())
+            key = f"{self.file.relative}-{mtime}-{func.__name__}"
+            cached = self.cache.get(key)
+            if not cached:
+                cached = func(self)
+                self.cache[key] = cached
+            return cached
+
+        return inner
+
+    @property
+    @_cache
+    def hash(self) -> str:
+        log.info(f"Hashing {self.file.relative}")
+        return self.file.hash
+
+    @property
+    @_cache
+    def meta(self) -> MediaMeta:
+        log.info(f"Parsing meta from {self.file.relative}")
+        return MediaMeta.from_uri(self.file.absolute)
+
+    @property
+    @_cache
+    def subtitles(self) -> Sequence[Subtitle]:
+        log.info(f"Parsing subtitles from {self.file.relative}")
+        return parse_subtitles(self.file.text)
+
+    @property
+    def lyrics(self) -> Sequence[str]:
+        return [l.text for l in self.subtitles]
+
+    @property
+    @_cache
+    def tags(self) -> Mapping[str, Sequence[str]]:
+        log.info(f"Parsing tags from {self.file.relative}")
+        return parse_tags(self.file.text)

--- a/processmedia3/lib/target.py
+++ b/processmedia3/lib/target.py
@@ -1,0 +1,68 @@
+import re
+import hashlib
+import base64
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from collections.abc import Set
+
+
+from .kktypes import TargetType
+from .source import Source
+from .encoders import find_appropriate_encoder
+
+
+log = logging.getLogger()
+
+
+class Target:
+    """
+    A file in the "processed" directory, with a method to figure out
+    the target name (based on the hash of the source files + encoder
+    settings), and a method to create that file if it doesn't exist.
+    """
+
+    def __init__(
+        self, processed_dir: Path, type: TargetType, sources: Set[Source]
+    ) -> None:
+
+        self.processed_dir = processed_dir
+        self.type = type
+        self.encoder, self.sources = find_appropriate_encoder(type, sources)
+
+        parts = [self.encoder.salt] + [s.hash for s in self.sources]
+        hasher = hashlib.sha256()
+        hasher.update("".join(sorted(parts)).encode("ascii"))
+        hash = re.sub("[+/=]", "_", base64.b64encode(hasher.digest()).decode("ascii"))
+        self.friendly = hash[0].lower() + "/" + hash[:11] + "." + self.encoder.ext
+        self.path = (
+            processed_dir / hash[0].lower() / (hash[:11] + "." + self.encoder.ext)
+        )
+        log.debug(
+            f"Filename for {self.encoder.__class__.__name__} = {self.friendly} based on {parts}"
+        )
+
+    def encode(self) -> None:
+        log.info(
+            f"{self.encoder.__class__.__name__}("
+            f"{self.friendly!r}, "
+            f"{[s.file.relative for s in self.sources]})"
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            temppath = Path(tempdir) / ("out." + self.encoder.ext)
+            try:
+                self.encoder.encode(temppath, self.sources)
+                if not temppath.exists():
+                    raise Exception("Encoder didn't return any error, but failed to create an output file")
+                if temppath.stat().st_size == 0:
+                    raise Exception("Encoder didn't return any error, but created an empty file")
+                self.path.parent.mkdir(exist_ok=True)
+                log.debug(f"Moving {temppath} to {self.path}")
+                shutil.move(temppath.as_posix(), self.path.as_posix())
+            except Exception as e:
+                log.error(f"Error while encoding {self.friendly!r}: {e}")
+
+    def __str__(self):
+        source_list = [s.file.relative for s in self.sources]
+        return f"{self.type.name}: {self.friendly!r} = {self.encoder.__class__.__name__}({source_list!r})"

--- a/processmedia3/main.py
+++ b/processmedia3/main.py
@@ -21,7 +21,10 @@ from collections.abc import Mapping, Sequence, MutableMapping, MutableSet, Set
 from tqdm.contrib.concurrent import thread_map
 from tqdm.contrib.logging import logging_redirect_tqdm
 
-from lib.kktypes import Source, SourceType, TargetType, Track, Target, TrackDict
+from lib.source import Source, SourceType
+from lib.target import Target
+from lib.track import Track, TrackDict
+from lib.kktypes import TargetType
 from lib.file_abstraction import AbstractFolder, AbstractFile, AbstractFolder_from_str, LocalFile
 
 

--- a/processmedia3/tests/test_main.py
+++ b/processmedia3/tests/test_main.py
@@ -4,10 +4,10 @@ import tempfile
 from functools import partialmethod
 from pathlib import Path
 import unittest
-from datetime import datetime
 
 import main
-from lib.kktypes import SourceType, TargetType
+from lib.source import SourceType
+from lib.kktypes import TargetType
 from lib.file_abstraction import AbstractFolder_from_str
 from tqdm import tqdm
 


### PR DESCRIPTION

Having "Source" and "Target" in the same file but "Encoders" separately caused issues because Targets need Encoders which need Sources
