### PR TITLE
[pm3] Give Track more control over Target generation

### DIFF
--- a/processmedia3/lib/target.py
+++ b/processmedia3/lib/target.py
@@ -10,7 +10,7 @@ from collections.abc import Set
 
 from .kktypes import TargetType
 from .source import Source
-from .encoders import find_appropriate_encoder
+from .encoders import Encoder
 
 
 log = logging.getLogger()
@@ -24,12 +24,17 @@ class Target:
     """
 
     def __init__(
-        self, processed_dir: Path, type: TargetType, sources: Set[Source]
+        self,
+        processed_dir: Path,
+        type: TargetType,
+        encoder: Encoder,
+        sources: Set[Source],
     ) -> None:
 
         self.processed_dir = processed_dir
         self.type = type
-        self.encoder, self.sources = find_appropriate_encoder(type, sources)
+        self.encoder = encoder
+        self.sources = sources
 
         parts = [self.encoder.salt] + [s.hash for s in self.sources]
         hasher = hashlib.sha256()

--- a/processmedia3/lib/track.py
+++ b/processmedia3/lib/track.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence, Mapping, MutableMapping, MutableSequence, 
 from .kktypes import MediaType, TargetType
 from .source import Source, SourceType
 from .target import Target
+from .encoders import find_appropriate_encoder
 
 
 class TrackAttachment(t.TypedDict):
@@ -37,7 +38,11 @@ class Track:
     ) -> None:
         self.id = id
         self.sources = sources
-        self.targets = [Target(processed_dir, type, sources) for type in target_types]
+        targets = []
+        for target_type in target_types:
+            target_encoder, target_sources = find_appropriate_encoder(target_type, sources)
+            targets.append(Target(processed_dir, target_type, target_encoder, target_sources))
+        self.targets = targets
 
     def _sources_by_type(self, types: Set[SourceType]) -> Sequence[Source]:
         return [s for s in self.sources if s.type in types]


### PR DESCRIPTION

Rather than "exactly one Target per TargetType, and let Target figure out the details", we might want multiple Targets per TargetType (ie, variants) - in which case we need to figure this out at a higher level
