### PR TITLE
[br3,pl3] only use text/vtt files as HTML video subtitles

### DIFF
--- a/browser3/src/screens/track.tsx
+++ b/browser3/src/screens/track.tsx
@@ -155,13 +155,15 @@ export function TrackDetails(): React.ReactElement {
                         type={a.mime}
                     />
                 ))}
-                {track.attachments.subtitle?.map((a) => (
-                    <track
-                        key={a.path}
-                        src={attachment_path(root, a)}
-                        default={true}
-                    />
-                ))}
+                {track.attachments.subtitle
+                    ?.filter((a) => a.mime === "text/vtt")
+                    .map((a) => (
+                        <track
+                            key={a.path}
+                            src={attachment_path(root, a)}
+                            default={true}
+                        />
+                    ))}
             </video>
 
             {/* Tags */}

--- a/player3/src/screens/_common.tsx
+++ b/player3/src/screens/_common.tsx
@@ -28,16 +28,18 @@ export function Video({ track, ...kwargs }: VideoProps) {
                         type={a.mime}
                     />
                 ))}
-                {track.attachments.subtitle?.map((a: Attachment) => (
-                    <track
-                        key={a.path}
-                        kind="subtitles"
-                        src={attachment_path(root, a)}
-                        default={true}
-                        label="English"
-                        srcLang="en"
-                    />
-                ))}
+                {track.attachments.subtitle
+                    ?.filter((a) => a.mime === "text/vtt")
+                    .map((a: Attachment) => (
+                        <track
+                            key={a.path}
+                            kind="subtitles"
+                            src={attachment_path(root, a)}
+                            default={true}
+                            label="English"
+                            srcLang="en"
+                        />
+                    ))}
             </video>
         </div>
     );

--- a/player3/src/screens/podium.tsx
+++ b/player3/src/screens/podium.tsx
@@ -51,15 +51,17 @@ export function PodiumScreen({
                     crossOrigin="anonymous"
                 >
                     <source src={blank.href} />
-                    {track.attachments.subtitle?.map((a) => (
-                        <track
-                            kind="subtitles"
-                            src={attachment_path(root, a)}
-                            default={true}
-                            label="English"
-                            srcLang="en"
-                        />
-                    ))}
+                    {track.attachments.subtitle
+                        ?.filter((a) => a.mime === "text/vtt")
+                        .map((a) => (
+                            <track
+                                kind="subtitles"
+                                src={attachment_path(root, a)}
+                                default={true}
+                                label="English"
+                                srcLang="en"
+                            />
+                        ))}
                 </video>
             ) : (
                 <Video track={track} lowres={true} loop={true} />


### PR DESCRIPTION

In the future we might want other subtitles for other purposes (eg, JSON subtitles for custom rendering)
