### PR TITLE
[br3] Make printable QR code cleaner

### DIFF
--- a/browser3/package-lock.json
+++ b/browser3/package-lock.json
@@ -16,6 +16,7 @@
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
                 "react-router-dom": "^7.5.3",
+                "react-to-print": "^3.1.1",
                 "usehooks-ts": "^3.1.1"
             },
             "devDependencies": {
@@ -8942,6 +8943,15 @@
             "peerDependencies": {
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/react-to-print": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-3.1.1.tgz",
+            "integrity": "sha512-N0MUMhpl8nkGri13BjP7zusj3B/j+1eMOTt8N8PYuhBYGzA4PqTXqcihJ9cZw996dvhV6mBdwafIQCg3Ap5bKg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ~19"
             }
         },
         "node_modules/reflect.getprototypeof": {

--- a/browser3/package.json
+++ b/browser3/package.json
@@ -22,6 +22,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.3",
+        "react-to-print": "^3.1.1",
         "usehooks-ts": "^3.1.1"
     },
     "devDependencies": {

--- a/browser3/src/screens/printable.tsx
+++ b/browser3/src/screens/printable.tsx
@@ -1,16 +1,18 @@
-import { useContext } from "react";
+import { useContext, useRef } from "react";
 import { BackToExplore, Screen } from "./_common";
 import { useParams } from "react-router-dom";
 import { ClientContext } from "../providers/client";
 import { QRCodeSVG } from "qrcode.react";
+import { useReactToPrint } from "react-to-print";
 
 ///////////////////////////////////////////////////////////////////////
 // Views
 
-const PrintButtons = (): React.ReactElement => (
+const PrintButtons = ({ callback } : { callback: () => void}): React.ReactElement => (
+
     <footer>
         <div className={"buttons"}>
-            <button type="button" onClick={() => window.print()}>
+            <button type="button" onClick={callback}>
                 Print
             </button>
         </div>
@@ -21,23 +23,28 @@ export function Printable(): React.ReactElement {
     const { roomName } = useParams();
     const { root } = useContext(ClientContext);
 
+    const contentRef = useRef<HTMLDivElement>(null);
+    const reactToPrintFn = useReactToPrint({ contentRef });
+
     return (
         <Screen
             className={"track_list"}
             navLeft={<BackToExplore />}
             title={"Track List"}
             //navRight={}
-            footer={<PrintButtons />}
+            footer={<PrintButtons callback={reactToPrintFn} />}
         >
-            <p>
-                To get an interactive track list on your phone, scan this QR
-                code or visit {root} and use room name "{roomName}".
-            </p>
-            <div className={"qr_container"}>
-                <QRCodeSVG
-                    value={`${root}/browser3/${roomName}`}
-                    className={"qr_code"}
-                />
+            <div ref={contentRef} className="printableContent">
+                <p>
+                    To get an interactive track list on your phone, scan this QR
+                    code or visit {root} and use room name "{roomName}".
+                </p>
+                <div className={"qr_container"}>
+                    <QRCodeSVG
+                        value={`${root}/browser3/${roomName}`}
+                        className={"qr_code"}
+                    />
+                </div>
             </div>
         </Screen>
     );

--- a/browser3/src/static/style.scss
+++ b/browser3/src/static/style.scss
@@ -601,17 +601,10 @@ MAIN.queue ARTICLE {
 }
 
 @media print {
-    @page {
-        size: landscape;
-    }
-    MAIN {
-        position: relative;
-        HEADER {
-            display: none !important;
-        }
-        FOOTER {
-            display: none !important;
-        }
+    .printableContent P {
+        font-size: 20pt;
+        text-align: center;
+        padding: 3cm 3cm 1cm 3cm;
     }
 }
 


### PR DESCRIPTION

Printing the entire page, with header and footer hidden via CSS, was suboptimal (eg, if the user was in two-column view, it would try to print both columns). The react-to-print library allows printing just a specific DIV, which seems to give better results.
